### PR TITLE
Display lives

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,33 +5,38 @@ import GameBoard from './components/GameBoard';
 import {loadDictionary} from "./api/apiCalls";
 
 class App extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      lives: 6,
-      words: []
+    constructor(props) {
+        super(props);
+        this.state = {
+            difficulty: 1,
+            lives: 6,
+            words: []
+        }
     }
-  }
 
-  componentDidMount() {
-    loadDictionary()
-        .then( res => {
-          this.setState({words: this.state.words.concat(res.filter(w => w.length < 10))})
-        });
-  }
+    componentDidMount() {
+        loadDictionary(this.state.difficulty)
+            .then( res => {
+                this.setState({words: this.state.words.concat(res.filter(w => w.length < 10))})
+            });
+    }
 
-  getNextWord() {
-      return this.state.words[Math.floor(Math.random()*this.state.words.length)]
-  }
+    setDifficulty(level) {
+        this.setState({difficulty: level});
+    }
 
-  render() {
-    return (
-      <div className="App container">
-        <Title name={'Word Play'} />
-        <GameBoard nextWord={() => this.getNextWord()} />
-      </div>
-    );
-  }
+    getNextWord() {
+        return this.state.words[Math.floor(Math.random()*this.state.words.length)]
+    }
+
+    render() {
+        return (
+            <div className="App container">
+                <Title name={'Word Play'} />
+                <GameBoard nextWord={() => this.getNextWord()} setDifficulty={(level) => this.setDifficulty(level)}/>
+            </div>
+        );
+    }
 }
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,7 @@ class App extends Component {
   componentDidMount() {
     loadDictionary()
         .then( res => {
-          this.setState({words: this.state.words.concat(res)})
+          this.setState({words: this.state.words.concat(res.filter(w => w.length < 10))})
         });
   }
 

--- a/src/api/apiCalls.js
+++ b/src/api/apiCalls.js
@@ -1,6 +1,7 @@
-export const loadDictionary = async () => {
+export const loadDictionary = async (difficulty) => {
+    console.log("Loading Difficulty '" + difficulty + "'");
     const proxyurl = "https://cors-anywhere.herokuapp.com/";
-    const url = "http://app.linkedin-reach.io/words";
+    const url = "http://app.linkedin-reach.io/words?difficulty=" + difficulty;
     const response = await fetch(proxyurl + url);
 
     let words = await response.text();

--- a/src/components/GameBoard.js
+++ b/src/components/GameBoard.js
@@ -19,22 +19,42 @@ class GameBoard extends Component {
     }
 
     processGuess(guess) {
-        console.log("Process Guess For: " + guess);
+        if (this.state.gameState !== 'active')
+            return null;
+
+        let attemptsRemaining = this.state.attempts;
         if (!this.state.guesses.includes(guess))
             this.setState({guesses: this.state.guesses.concat(guess)},
                 () => {
                     if (!this.state.secretWord.includes(guess))
-                        this.setState({attempts: this.state.attempts - 1},
-                            () => {
-                                if (this.state.attempts === 0)
-                                    this.gameOver();
-                            });
-                }
-            );
+                        attemptsRemaining -= 1;
+
+                    this.setState({attempts: attemptsRemaining}, () => this.winOrLose());
+                });
     }
 
-    gameOver() {
-        this.setState({gameState: 'lost'});
+    winOrLose() {
+        if (this.state.attempts > 0 && !this.hasAllLetters())
+            return null;
+
+        if (this.state.attempts <= 0 && !this.hasAllLetters()) {
+            console.log("GAME OVER!");
+            this.setState({gameState: 'lost'});
+        } else if (this.hasAllLetters()) {
+            console.log("YOU WIN!");
+            this.setState({gameState: 'won'});
+        }
+    }
+
+    hasAllLetters() {
+        let matches = 0;
+
+        this.state.secretWord.split('').forEach( char =>{
+            if (this.state.guesses.includes(char))
+                matches += 1;
+        });
+
+        return (matches === this.state.secretWord.length);
     }
 
     startGame() {
@@ -55,7 +75,7 @@ class GameBoard extends Component {
             button = <button className={'btn btn-success'} onClick={this.startGame}>Start New Game</button>
         } else {
             button = <div className={'spinner-border m-5'} role={'status'}>
-            <span className={'sr-only'}>Loading...</span>
+                <span className={'sr-only'}>Loading...</span>
             </div>
         }
 
@@ -63,6 +83,7 @@ class GameBoard extends Component {
             case 'won':
                 return (
                     <div>
+                        <SolutionArea solution={this.state.secretWord} guesses={this.state.guesses} reveal={true}/>
                         <h2><strong>Winner!!</strong></h2>
                         <button className={'btn btn-success'} onClick={this.startGame}>Start New Game</button>
                     </div>
@@ -77,7 +98,7 @@ class GameBoard extends Component {
                 );
             case 'active':
                 return (
-                    <SolutionArea solution={this.state.secretWord} guesses={this.state.guesses} processGuess={this.processGuess}/>
+                    <SolutionArea solution={this.state.secretWord} guesses={this.state.guesses}/>
                 );
             default:
                 return (

--- a/src/components/GameBoard.js
+++ b/src/components/GameBoard.js
@@ -8,7 +8,7 @@ class GameBoard extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            secretWord: [],
+            secretWord: '',
             gameState: 'inactive',
             guesses: [],
             attempts: 4
@@ -22,8 +22,19 @@ class GameBoard extends Component {
         console.log("Process Guess For: " + guess);
         if (!this.state.guesses.includes(guess))
             this.setState({guesses: this.state.guesses.concat(guess)},
-                () => console.log(this.state.guesses)
+                () => {
+                    if (!this.state.secretWord.includes(guess))
+                        this.setState({attempts: this.state.attempts - 1},
+                            () => {
+                                if (this.state.attempts === 0)
+                                    this.gameOver();
+                            });
+                }
             );
+    }
+
+    gameOver() {
+        this.setState({gameState: 'lost'});
     }
 
     startGame() {
@@ -40,23 +51,30 @@ class GameBoard extends Component {
 
     renderGame() {
         let button;
-        if (this.state.secretWord) {
+        if (this.state.secretWord.length < 1) {
             button = <button className={'btn btn-success'} onClick={this.startGame}>Start New Game</button>
         } else {
             button = <div className={'spinner-border m-5'} role={'status'}>
             <span className={'sr-only'}>Loading...</span>
             </div>
         }
+
         switch (this.state.gameState) {
             case 'won':
                 return (
                     <div>
                         <h2><strong>Winner!!</strong></h2>
-                        <button onClick={this.startGame}>Start New Game</button>
+                        <button className={'btn btn-success'} onClick={this.startGame}>Start New Game</button>
                     </div>
                 );
             case 'lost':
-                return (<h2><strong>Try Again!</strong></h2>);
+                return (
+                    <div>
+                        <SolutionArea solution={this.state.secretWord} guesses={this.state.guesses} reveal={true}/>
+                        <h2><strong>Try Again!</strong></h2>
+                        <button className={'btn btn-success'} onClick={this.startGame}>Start New Game</button>
+                    </div>
+                );
             case 'active':
                 return (
                     <SolutionArea solution={this.state.secretWord} guesses={this.state.guesses} processGuess={this.processGuess}/>

--- a/src/components/Keyboard.js
+++ b/src/components/Keyboard.js
@@ -45,6 +45,9 @@ class Keyboard extends Component {
                         {char.value}
                     </div>
                 )}
+                <div id={'advertisements'}>
+                    <small><em>ADVERTISEMNT BANNER HERE</em></small>
+                </div>
             </div>
         )
     }

--- a/src/components/Keyboard.js
+++ b/src/components/Keyboard.js
@@ -18,7 +18,7 @@ class Keyboard extends Component {
     }
 
     buildStyleClasses(letter) {
-        if (this.props.gameState === 'inactive')
+        if (this.props.gameState !== 'active')
             return 'keyboard-tile disabled';
 
         let styleClasses = 'keyboard-tile ';

--- a/src/components/LetterTile.js
+++ b/src/components/LetterTile.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import '../styles/letterTile.css';
+import '../styles/solutionArea.css';
 
 class LetterTile extends Component {
     constructor(props) {
@@ -10,7 +10,6 @@ class LetterTile extends Component {
     }
 
     letterToShow(letter) {
-        console.log(this.props.className);
         let givenChars = [".", ",", "-"];
         if (givenChars.includes(letter) || letter.found)
             return letter.value;

--- a/src/components/Lives.js
+++ b/src/components/Lives.js
@@ -10,7 +10,7 @@ class Lives extends Component {
             if (i < this.props.attempts)
                 toRender.push(<i className={'fas fa-heart'} key={i}></i>);
             else
-                toRender.push( <i className={'far fa-heart'} key={i}></i> );
+                toRender.push( <i className={'fas fa-heart empty'} key={i}></i> );
         }
         return toRender;
     }

--- a/src/components/SolutionArea.js
+++ b/src/components/SolutionArea.js
@@ -10,17 +10,27 @@ class SolutionArea extends Component {
     letterToRender(letter) {
         let found = this.props.guesses.includes(letter);
 
-        if (found)
-            return letter;
+        if (found || this.props.gameState === 'lost' || this.props.gameState === 'won' ){
+            debugger;
+            return letter;}
         else
             return " ";
+    }
+
+    buildStyleClasses(letter) {
+        let classes = ['letter-tile'];
+        if (this.props.reveal)
+            classes.push('revealed');
+        if (this.props.gameState === 'won')
+            classes.push('winner');
+        return classes.join(' ');
     }
 
     render() {
         return(
             <div id={'solution-area'}>
                 {this.props.solution.split('').map((letter, index) =>
-                        <div key={index} className={'letter-tile'} onClick={() => this.props.processGuess(letter)}>
+                        <div key={index} className={this.buildStyleClasses(letter)} onClick={() => this.props.processGuess(letter)}>
                             {this.letterToRender(letter)}
                         </div>
                 )}

--- a/src/components/SolutionArea.js
+++ b/src/components/SolutionArea.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import '../styles/letterTile.css';
+import '../styles/solutionArea.css';
 
 class SolutionArea extends Component {
 
@@ -10,16 +10,15 @@ class SolutionArea extends Component {
     letterToRender(letter) {
         let found = this.props.guesses.includes(letter);
 
-        if (found || this.props.gameState === 'lost' || this.props.gameState === 'won' ){
-            debugger;
-            return letter;}
+        if (found || this.props.gameState === 'lost' || this.props.gameState === 'won' || this.props.reveal === true )
+            return letter;
         else
             return " ";
     }
 
     buildStyleClasses(letter) {
         let classes = ['letter-tile'];
-        if (this.props.reveal)
+        if (this.props.reveal && !this.props.guesses.includes(letter))
             classes.push('revealed');
         if (this.props.gameState === 'won')
             classes.push('winner');
@@ -30,7 +29,7 @@ class SolutionArea extends Component {
         return(
             <div id={'solution-area'}>
                 {this.props.solution.split('').map((letter, index) =>
-                        <div key={index} className={this.buildStyleClasses(letter)} onClick={() => this.props.processGuess(letter)}>
+                        <div key={index} className={this.buildStyleClasses(letter)}>
                             {this.letterToRender(letter)}
                         </div>
                 )}

--- a/src/styles/gameBoard.css
+++ b/src/styles/gameBoard.css
@@ -2,7 +2,7 @@
     padding: 25px;
     box-sizing: border-box;
     position: relative;
-    height: 30vh;
+    height: 35vh;
     border: solid 1px black;
     border-radius: 5%;
 }

--- a/src/styles/keyboard.css
+++ b/src/styles/keyboard.css
@@ -15,6 +15,14 @@
     margin: 5px;
 }
 
+#advertisements {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    height: 50px;
+    background-color: lightgreen;
+}
+
 .keyboard-tile.chosen {
     background-color: rgba(130, 130, 130, 0.65);
 }

--- a/src/styles/letterTile.css
+++ b/src/styles/letterTile.css
@@ -14,6 +14,6 @@
     font-weight: bold;
     color: black;
 }
-.letter-tile.hidden {
-    color: white;
+.letter-tile.revealed {
+    opacity: 60%;
 }

--- a/src/styles/lives.css
+++ b/src/styles/lives.css
@@ -2,5 +2,11 @@
     color: red;
     font-size: 1.5em;
     margin: 0 5px;
-    transition: 0.4s;
+    transition: .3s;
+}
+
+.fa-heart.empty {
+    opacity: 0.15;
+    color: gray;
+    transition: .25s;
 }

--- a/src/styles/solutionArea.css
+++ b/src/styles/solutionArea.css
@@ -1,6 +1,6 @@
 #solution-area {
     text-align: center;
-    margin-top: 2rem;
+    margin: 2rem 0 1rem 0;
 }
 
 .letter-tile {
@@ -15,5 +15,6 @@
     color: black;
 }
 .letter-tile.revealed {
-    opacity: 60%;
+    color: red;
+    background-color: lightgray;
 }


### PR DESCRIPTION
Added logic to increase the `level` of difficulty after every five completed puzzles.  Remaining guesses denoted by `heart` symbols from FontAwesome.  Guesses remaining are represented by fully illuminated red hearts, and expended guesses are represented by greyed out, and less illuminated hearts.

Conditionally rendered GameBoard contents (Lives, SolutionArea, Win/Lose Notice, and Play Again button).