### PR TITLE
Added Keyboard Input Support

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,37 @@ class App extends Component {
 
     componentDidMount() {
         this.getWords();
+        document.addEventListener("keypress", this.handleKeyPress);
+    }
+
+    handleKeyPress(e) {
+        let handled = false;
+        let visible = null;
+        if (e.isTrusted) {
+            if (e.key === 'Enter') {
+                visible = document.getElementsByClassName(' new-game-btn');
+                try {
+                    visible = visible[0];
+                } catch(e) {
+                    console.log("An error occured while checking the class of the form on line 29 of 'App.js'\n\n");
+                    console.log(visible);
+                    console.log(e);
+                }
+                if (visible) {
+                    console.log(visible);
+                    visible.click();
+                }
+            }
+            let keyboardTiles = document.getElementsByClassName('keyboard-tile');
+            for (let key of keyboardTiles) {
+                if (key.innerText === e.key.toUpperCase()) {
+                    key.click();
+                    handled = true;
+                }
+            }
+        }
+        if (handled)
+            e.preventDefault();
     }
 
     getWords() {

--- a/src/components/GameBoard.js
+++ b/src/components/GameBoard.js
@@ -78,7 +78,7 @@ class GameBoard extends Component {
         let button;
         if (this.state.secretWord.length < 1 && this.state.gameState === 'inactive') {
             button =
-                <button className={'btn btn-success btn-lg'} onClick={this.startGame}><strong>Start New Game</strong>
+                <button className={'btn btn-success btn-lg new-game-btn'} onClick={this.startGame}><strong>Start New Game</strong>
                 </button>
         } else {
             button = <div className={'spinner-border m-5'} role={'status'}>
@@ -92,7 +92,7 @@ class GameBoard extends Component {
                     <div>
                         <SolutionArea solution={this.state.secretWord} guesses={this.state.guesses} reveal={true}/>
                         <h2><strong>Winner!!</strong></h2>
-                        <button className={'btn btn-success'} onClick={this.startGame}>Start New Game</button>
+                        <button className={'btn btn-success new-game-btn'} onClick={this.startGame}>Start New Game</button>
                     </div>
                 );
             case 'lost':
@@ -100,7 +100,7 @@ class GameBoard extends Component {
                     <div>
                         <SolutionArea solution={this.state.secretWord} guesses={this.state.guesses} reveal={true}/>
                         <h2><strong>Try Again!</strong></h2>
-                        <button className={'btn btn-success'} onClick={this.startGame}>Start New Game</button>
+                        <button className={'btn btn-success new-game-btn'} onClick={this.startGame}>Start New Game</button>
                     </div>
                 );
             case 'active':
@@ -162,7 +162,7 @@ class GameBoard extends Component {
                                 id={'guess'}
                                 onChange={(e) => this.onChange(e)}
                             />
-                            <button type={'submit'} className={'btn btn-primary'}>Submit</button>
+                            <button id={'guess-word-submit'} type={'submit'} className={'btn btn-primary'}>Submit</button>
                         </form>
                     </div>
                 </div>


### PR DESCRIPTION
Added support for keyboard input to select letters, and start new game.  When on puzzle is active, pressing `ENTER` will cause a `click()` action on the `Start New Game!` button.  When a game is active, players may use a keyboard to select letters instead of a mouse (or in addition to).

Mobile users are only able to use the keyboard to attempt at guessing the full word.